### PR TITLE
Adds Colored Output

### DIFF
--- a/lib/cane.rb
+++ b/lib/cane.rb
@@ -2,6 +2,7 @@ require 'cane/abc_check'
 require 'cane/style_check'
 require 'cane/doc_check'
 require 'cane/threshold_check'
+require 'cane/colored_formatter'
 require 'cane/violation_formatter'
 
 module Cane
@@ -26,7 +27,8 @@ module Cane
     end
 
     def run
-      outputter.print ViolationFormatter.new(violations)
+      klass = @opts[:output][:color] ? ColoredFormatter : ViolationFormatter
+      outputter.print klass.new(violations)
 
       violations.length <= opts.fetch(:max_violations)
     end

--- a/lib/cane/cli/spec.rb
+++ b/lib/cane/cli/spec.rb
@@ -13,6 +13,7 @@ module Cane
         style_measure:  '80',
         doc_glob:       'lib/**/*.rb',
         max_violations: '0',
+        color: false,
       }
 
       # Exception to indicate that no further processing is required and the
@@ -22,6 +23,7 @@ module Cane
       def initialize
         add_banner
 
+        add_colors
         add_abc_options
         add_style_options
         add_doc_options
@@ -55,6 +57,12 @@ Usage: cane [options]
 You can also put these options in a .cane file.
 
 BANNER
+      end
+
+      def add_colors
+        parser.on("--color", "Colorize the output") do |opts|
+          options[:color] = true
+        end
       end
 
       def add_abc_options

--- a/lib/cane/cli/translator.rb
+++ b/lib/cane/cli/translator.rb
@@ -6,6 +6,7 @@ module Cane
     class Translator < Struct.new(:options, :defaults)
       def to_hash
         result = {}
+        translate_output_options(result)
         translate_abc_options(result)
         translate_doc_options(result)
         translate_style_options(result)
@@ -14,6 +15,12 @@ module Cane
         result[:max_violations] = option_with_default(:max_violations).to_i
 
         result
+      end
+
+      def translate_output_options(result)
+        result[:output] = {
+          color: option_with_default(:color)
+        }
       end
 
       def translate_abc_options(result)

--- a/lib/cane/colored_formatter.rb
+++ b/lib/cane/colored_formatter.rb
@@ -1,0 +1,47 @@
+require 'term/ansicolor'
+require 'cane/violation_formatter'
+
+module Cane
+  # Just a formatter, based on ViolationFormatter, for colored output
+  # for the violations.
+  class ColoredFormatter < ViolationFormatter
+    include Term::ANSIColor
+    INFINITY = (1/0.0)
+
+    protected
+
+    def format_group_header(description, violations)
+      desc = [white, description, reset].join
+      count = case violations.length
+              when 0..5
+                [yellow, violations.length.to_s, clear].join
+              when 6..10
+                [red, violations.length.to_s, clear].join
+              when 11..INFINITY
+                [bold, red, violations.length.to_s, clear].join
+              end
+
+      ["", "%s (%s):" % [desc, count], ""]
+    end
+
+    def format_violation(violation, widths)
+      columns = violation.columns.map
+      columns = columns.with_index do |column,i|
+        "%-#{widths[i]}s" % parse(column)
+      end
+
+      ['  ' + columns.join('  ')]
+    end
+
+    private
+
+    def parse(column)
+      if column =~ /.*:\d+$/
+        column = column.split(':')
+        [yellow, column[0], clear, ':', column[1]].join
+      else
+        [red, column, clear].join
+      end
+    end
+  end
+end

--- a/spec/cane_spec.rb
+++ b/spec/cane_spec.rb
@@ -96,6 +96,13 @@ describe 'Cane' do
     end
   end
 
+  it "accepts colored output" do
+    output, exitstatus = run("--help")
+
+    exitstatus.should == 0
+    output.should include("--color")
+  end
+
   it 'displays a help message' do
     output, exitstatus = run("--help")
 

--- a/spec/colored_formatter_spec.rb
+++ b/spec/colored_formatter_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe Cane::ColoredFormatter do
+  class Color
+    extend Term::ANSIColor
+  end
+
+  def violation(description)
+    stub("violation",
+      description: description,
+      columns: ["app/foo.rb:1", "MyClass"]
+    )
+  end
+
+  def violations(count, description)
+    (0...count).map { violation(description) }
+  end
+
+  context "group header" do
+    it "has a description" do
+      output = [Color.white, "FAIL", Color.reset].join
+      described_class.new(violations(1, "FAIL")).to_s.should include(output)
+    end
+
+    context "number of violations" do
+      it 'for 1..5' do
+        output = "(#{Color.yellow}1#{Color.reset})"
+        described_class.new(violations(1,"FAIL")).to_s.should include(output)
+      end
+
+      it 'for 6..10' do
+        output = "(#{Color.red}6#{Color.reset})"
+        described_class.new(violations(6,"FAIL")).to_s.should include(output)
+      end
+
+      it 'for 11..Infinity' do
+        output = "(#{Color.bold}#{Color.red}11#{Color.reset})"
+        described_class.new(violations(11,"FAIL")).to_s.should include(output)
+      end
+    end
+  end
+
+  context "file violations" do
+    it "colorizes the file name" do
+      output = [Color.yellow, "app/foo.rb", Color.clear, ":1"].join
+      described_class.new(violations(1,"FAIL")).to_s.should include(output)
+    end
+
+    it "colorizes the class name" do
+      output = [Color.red, "MyClass", Color.clear].join
+      described_class.new(violations(1,"FAIL")).to_s.should include(output)
+    end
+  end
+end


### PR DESCRIPTION
The colored output is enabled using `--color` as an option, and is disabled by default. It adds a new formatter, using ViolationFormatter as a base.

Uses Term::ANSIColors as a dependency (since it's already required by Tailor).
