### PR TITLE
Line length checks no longer include trailing new lines in the count.

### DIFF
--- a/lib/cane/style_check.rb
+++ b/lib/cane/style_check.rb
@@ -81,7 +81,7 @@ module Cane
 
     # Copy of parent method using a configurable line length.
     def too_long?
-      length = self.length
+      length = self.chomp.length
       if length > line_length_max
         print_problem "Line is >#{line_length_max} characters (#{length})"
         return true

--- a/spec/cane_spec.rb
+++ b/spec/cane_spec.rb
@@ -54,6 +54,14 @@ describe 'Cane' do
     output.should include("Lines violated style requirements")
   end
 
+  it 'does not include trailing new lines in the character count' do
+    file_name = make_file('#' * 80 + "\n" + '#' * 80)
+
+    output, exitstatus = run("--style-glob #{file_name} --style-measure 80")
+    exitstatus.should == 0
+    output.should be_empty
+  end
+
   it 'allows upper bound of failed checks' do
     file_name = make_file("whitespace ")
 


### PR DESCRIPTION
cane dies on lines that are exactly 80 characters if they are in the middle of a file (i.e. include trailing new lines). It counts the new line as the 81st character. This commit corrects that.
