### PR TITLE
include total violation count in ViolationFormatter output

### DIFF
--- a/lib/cane/violation_formatter.rb
+++ b/lib/cane/violation_formatter.rb
@@ -11,10 +11,14 @@ module Cane
       grouped_violations.map do |description, violations|
         format_group_header(description, violations) +
           format_violations(violations)
-      end.flatten.join("\n") + "\n\n"
+      end.flatten.join("\n") + "\n\n" + totals + "\n\n"
     end
 
     protected
+
+    def totals
+      "Total Violations: #{violations.count}"
+    end
 
     def format_group_header(description, violations)
       ["", "%s (%i):" % [description, violations.length], ""]

--- a/spec/violation_formatter_spec.rb
+++ b/spec/violation_formatter_spec.rb
@@ -13,4 +13,10 @@ describe Cane::ViolationFormatter do
   it 'includes number of violations in the group header' do
     described_class.new([violation("FAIL")]).to_s.should include("(1)")
   end
+
+  it 'includes total number of violations' do
+    violations = [violation("FAIL1"),violation("FAIL2")]
+    result = described_class.new(violations).to_s
+    result.should include("Total Violations: 2")
+  end
 end


### PR DESCRIPTION
When adding cane to a legacy project and ratching down the max_violations setting it's handy to know what value to start with.

At the moment I need to manually sum the violation count for each grouping
