### PR TITLE
Minor bug fix - class + 2 spaces causes error

### DIFF
--- a/lib/cane/doc_check.rb
+++ b/lib/cane/doc_check.rb
@@ -60,7 +60,7 @@ module Cane
     end
 
     def extract_class_name(line)
-      line.match(/class ([^\s;]+)/)[1]
+      line.match(/class *?([^\s;]+)/)[1]
     end
 
     def worker

--- a/spec/doc_check_spec.rb
+++ b/spec/doc_check_spec.rb
@@ -35,7 +35,7 @@ end
   it 'ignores magic encoding comments' do
     file_name = make_file <<-RUBY
 # coding = utf-8
-class NoDoc; end
+class   NoDoc; end
 # -*-  encoding :  utf-8  -*-
 class AlsoNoDoc; end
 # Parse a Transfer-Encoding: Chunked response


### PR DESCRIPTION
Hi.
I hit a small issue with doc_check when 'class' is followed by more than 1 space.
Commit has an updated test that triggers it.

cheers,
michael.
