### PR TITLE
Allow options specified in ./.cane to be added to a rake task

### DIFF
--- a/lib/cane/cli/parser.rb
+++ b/lib/cane/cli/parser.rb
@@ -48,8 +48,12 @@ module Cane
       end
 
       def get_default_options
-        if Cane::File.exists?('./.cane')
-          Cane::File.contents('./.cane').split(/\s+/m)
+        read_options_from_file './.cane'
+      end
+
+      def read_options_from_file(file)
+        if Cane::File.exists?(file)
+          Cane::File.contents(file).split(/\s+/m)
         else
           []
         end

--- a/lib/cane/rake_task.rb
+++ b/lib/cane/rake_task.rb
@@ -45,7 +45,7 @@ module Cane
 
     def canefile=(file)
       canefile = Cane::CLI::Parser.new
-      canefile.parser.parse!(canefile.get_default_options)
+      canefile.parser.parse!(canefile.read_options_from_file(file))
       options.merge! canefile.options
     end
 

--- a/spec/rake_task_spec.rb
+++ b/spec/rake_task_spec.rb
@@ -32,6 +32,23 @@ describe Cane::RakeTask do
     out.should include("theopt")
   end
 
+  it 'can be configured using a .cane file' do
+    fn = make_file("90").strip
+
+    task = Cane::RakeTask.new(:canefile_quality) do |cane|
+      conf = "--gte #{fn},99"
+      cane.canefile = make_file(conf)
+    end
+
+
+    task.should_receive(:abort)
+    out = capture_stdout do
+      Rake::Task['canefile_quality'].invoke
+    end
+
+    out.should include("Quality threshold crossed")
+  end
+
   after do
     Rake::Task.clear
   end


### PR DESCRIPTION
So I can run 'cane' from the project root and get similar results to running it via rake.
