### PR TITLE
Support providing a filename containing a coverage threshold

### DIFF
--- a/lib/cane/threshold_check.rb
+++ b/lib/cane/threshold_check.rb
@@ -16,18 +16,18 @@ module Cane
     end
 
     def violations
-      thresholds.map do |operator, file, limit|
-        value = value_from_file(file)
+      thresholds.map do |operator, file, threshold|
+        value = normalized_limit(file)
+        limit = normalized_limit(threshold)
 
-        if limit.to_f != limit
-          if Cane::File.exists?(limit)
-            limit = value_from_file(limit)
-          else
-            limit = UnavailableValue.new
-          end
-        end
-
-        unless value.send(operator, limit.to_f)
+        if limit.is_a? UnavailableValue
+          {
+            description: 'Quality threshold could not be read',
+            label:       "%s is not a number or a file" % [
+              threshold
+            ]
+          }
+        elsif !value.send(operator, limit.to_f)
           {
             description: 'Quality threshold crossed',
             label:       "%s is %s, should be %s %s" % [
@@ -36,6 +36,13 @@ module Cane
           }
         end
       end.compact
+    end
+
+    def normalized_limit(limit)
+      if limit.to_f != limit
+        limit = value_from_file(limit)
+      end
+      limit
     end
 
     def value_from_file(file)

--- a/spec/threshold_check_spec.rb
+++ b/spec/threshold_check_spec.rb
@@ -3,11 +3,48 @@ require 'spec_helper'
 require 'cane/threshold_check'
 
 describe Cane::ThresholdCheck do
-  it 'returns a value of unavailable when file cannot be read' do
-    check = Cane::ThresholdCheck.new(gte: [['bogus_file', 20]])
-    violations = check.violations
-    violations.length.should == 1
-    violations[0][:label].should ==
-      'bogus_file is unavailable, should be >= 20'
+
+  context "checking violations" do
+
+    context "when the current coverage cannot be read" do
+      it 'reports a violation' do
+        check = Cane::ThresholdCheck.new(gte: [['bogus_file', 20]])
+        violations = check.violations
+        violations.length.should == 1
+        violations[0][:label].should ==
+          'bogus_file is unavailable, should be >= 20'
+      end
+    end
+
+    context "when the coverage threshold is incorrectly specified" do
+      it 'reports a violation' do
+        check = Cane::ThresholdCheck.new(gte: [[20, 'bogus_file']])
+        violations = check.violations
+        violations.length.should == 1
+        violations[0][:label].should ==
+          'bogus_file is not a number or a file'
+      end
+    end
+
   end
+
+  context "normalizing a user supplied value to a threshold" do
+    it "normalizes an integer to itself" do
+      subject.normalized_limit(99).should == 99
+    end
+
+    it "normalizes a float to itself" do
+      subject.normalized_limit(99.6).should == 99.6
+    end
+
+    it "normalizes a valid file to its contents" do
+      subject.normalized_limit(make_file('99.5')).should == 99.5
+    end
+
+    it "normalizes an invalid file to an unavailable value" do
+      limit = subject.normalized_limit("/File.does.not.exist")
+      limit.should be_a Cane::ThresholdCheck::UnavailableValue
+    end
+  end
+
 end


### PR DESCRIPTION
This allows you to invoke cane coverage checks as follows:

`cane --gte coverage/covered_percent,config/coverage_threshold`

so that the minimum coverage amount can be stored in source control.
