### PR TITLE
Require Ruby 1.9 in the gemspec

### DIFF
--- a/cane.gemspec
+++ b/cane.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "http://github.com/square/cane"
 
   gem.executables   = []
+  gem.required_ruby_version = '>= 1.9.0'
   gem.files         = Dir.glob("{spec,lib}/**/*.rb") + %w(
                         README.md
                         HISTORY.md


### PR DESCRIPTION
The gem should fail to install on old Ruby versions, as it won't run properly (see Issue #46)
