### PR TITLE
Allow documentation exclusions with --doc-exclude

### DIFF
--- a/spec/doc_check_spec.rb
+++ b/spec/doc_check_spec.rb
@@ -71,4 +71,17 @@ class Doc; end
       "Missing documentation", "No README found"
     ]
   end
+
+  it 'skips declared exclusions' do
+    file_name = make_file <<-FILE.gsub /^\s{6}/, ''
+      class NeedsDocumentation
+      end
+    FILE
+
+    violations = check(file_name,
+      doc_exclude: [file_name]
+    ).violations
+
+    violations.length.should == 0
+  end
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -63,11 +63,13 @@ describe Cane::CLI::Parser do
   it 'supports exclusions' do
     options = [
       "--abc-exclude", "Harness#complex_method",
+      "--doc-exclude", 'myfile',
       "--style-exclude", 'myfile'
     ].join(' ')
 
     _, result = run(options)
     result[:abc_exclude].should == [['Harness#complex_method']]
+    result[:doc_exclude].should == [['myfile']]
     result[:style_exclude].should == [['myfile']]
   end
 


### PR DESCRIPTION
My use case is a file that defines error classes https://github.com/RiotGames/berkshelf/blob/master/lib/berkshelf/errors.rb
