### PR TITLE
Suppress warning about IO#lines in Ruby 2.0

### DIFF
--- a/lib/cane/file.rb
+++ b/lib/cane/file.rb
@@ -7,7 +7,7 @@ module Cane
   class File
     class << self
       def iterator(path)
-        EncodingAwareIterator.new(open(path).lines)
+        EncodingAwareIterator.new(open(path).each_line)
       end
 
       def contents(path)


### PR DESCRIPTION
lib/cane/file.rb:10: warning: IO#lines is deprecated; use #each_line instead
