### PR TITLE
Add .markdown as a valid README extension

### DIFF
--- a/lib/cane/doc_check.rb
+++ b/lib/cane/doc_check.rb
@@ -62,7 +62,7 @@ module Cane
       return result if opts[:no_readme]
 
       filenames = ['README', 'readme']
-      extensions = ['', '.txt', '.md', '.mdown', '.rdoc']
+      extensions = ['', '.txt', '.md', '.mdown', '.rdoc', '.markdown']
       combinations = filenames.product(extensions)
 
       if combinations.none? {|n, x| Cane::File.exists?(n + x) }

--- a/spec/doc_check_spec.rb
+++ b/spec/doc_check_spec.rb
@@ -60,11 +60,13 @@ class Doc; end
     file.should_receive(:exists?).with("README").and_return(false)
     file.should_receive(:exists?).with("README.md").and_return(false)
     file.should_receive(:exists?).with("README.mdown").and_return(false)
+    file.should_receive(:exists?).with("README.markdown").and_return(false)
     file.should_receive(:exists?).with("README.txt").and_return(false)
     file.should_receive(:exists?).with("README.rdoc").and_return(false)
     file.should_receive(:exists?).with("readme").and_return(false)
     file.should_receive(:exists?).with("readme.md").and_return(false)
     file.should_receive(:exists?).with("readme.mdown").and_return(false)
+    file.should_receive(:exists?).with("readme.markdown").and_return(false)
     file.should_receive(:exists?).with("readme.txt").and_return(false)
     file.should_receive(:exists?).with("readme.rdoc").and_return(false)
 


### PR DESCRIPTION
Just a simple addition of README.markdown as a valid file name to check for.

If this will be accepted, I'll go ahead and sign the Individual Contributor Agreement linked to in the README.
