### PR TITLE
JsonFormatter initializer needs to take an options hash, because that's ...

### DIFF
--- a/lib/cane/json_formatter.rb
+++ b/lib/cane/json_formatter.rb
@@ -5,7 +5,7 @@ module Cane
   # Computes a machine-readable JSON representation from an array of violations
   # computed by the checks.
   class JsonFormatter
-    def initialize(violations)
+    def initialize(violations, options = {})
       @violations = violations
     end
 


### PR DESCRIPTION
...how the runner calls it now.

Fix for: https://github.com/square/cane/issues/74
