### PR TITLE
make it possible to specify an output file with a --out option

### DIFF
--- a/lib/cane/cli/parser.rb
+++ b/lib/cane/cli/parser.rb
@@ -121,6 +121,9 @@ BANNER
         add_option %w(--color),
           "Colorize output", default: false
 
+        add_option %w(--out VALUE),
+          "Output File", default: $stdout, cast: Proc.new {|value| ::File.open(value, 'w')}
+
         parser.separator ""
       end
 

--- a/spec/cane_spec.rb
+++ b/spec/cane_spec.rb
@@ -57,6 +57,13 @@ describe 'The cane application' do
     exitstatus.should == 1
   end
 
+  it 'outputs results to the specified file' do
+    output_file = SecureRandom.hex
+    exit_status = run_with_output_file("--out #{output_file}  --abc-max 0")
+    File.read(output_file).should include ("Total Violations")
+    File.delete(output_file)
+  end
+
   it 'handles invalid unicode input' do
     fn = make_file("\xc3\x28")
 
@@ -81,6 +88,12 @@ describe 'The cane application' do
     if Object.const_defined?(class_name)
       Object.send(:remove_const, class_name)
     end
+  end
+
+  def run_with_output_file(cli_args)
+    Cane::CLI.run(
+           %w(--no-abc --no-style --no-doc) + cli_args.split(/\s+/m)
+         ) ? 0 : 1
   end
 
   def run(cli_args)


### PR DESCRIPTION
Seems like somebody had this feature in mind at some point. In runner.rb there's this:

``` ruby
    def outputter
      opts.fetch(:out, $stdout)
    end
```

But there didn't seem to be any way to set that option. Now there is.
This ought to be useful in CI situations (save / publish report as build artifact etc.)
