### PR TITLE
Update specs to RSpec 2.14.7 syntax (Updated)

### DIFF
--- a/spec/abc_check_spec.rb
+++ b/spec/abc_check_spec.rb
@@ -18,7 +18,7 @@ describe Cane::AbcCheck do
     RUBY
 
     violations = check(file_name, abc_max: 1, no_abc: true).violations
-    violations.should be_empty
+    expect(violations).to be_empty
   end
 
   it 'creates an AbcMaxViolation for each method above the threshold' do
@@ -36,9 +36,10 @@ describe Cane::AbcCheck do
     RUBY
 
     violations = check(file_name, abc_max: 1, no_abc: false).violations
-    violations.length.should == 1
-    violations[0].values_at(:file, :label, :value).should ==
+    expect(violations.length).to eq(1)
+    expect(violations[0].values_at(:file, :label, :value)).to eq(
       [file_name, "Harness#complex_method", 2]
+    )
   end
 
   it 'sorts violations by complexity' do
@@ -56,9 +57,9 @@ describe Cane::AbcCheck do
     RUBY
 
     violations = check(file_name, abc_max: 0).violations
-    violations.length.should == 2
+    expect(violations.length).to eq(2)
     complexities = violations.map {|x| x[:value] }
-    complexities.should == complexities.sort.reverse
+    expect(complexities).to eq(complexities.sort.reverse)
   end
 
   it 'creates a violation when code cannot be parsed' do
@@ -67,9 +68,9 @@ describe Cane::AbcCheck do
     RUBY
 
     violations = check(file_name).violations
-    violations.length.should == 1
-    violations[0][:file].should == file_name
-    violations[0][:description].should be_instance_of(String)
+    expect(violations.length).to eq(1)
+    expect(violations[0][:file]).to eq(file_name)
+    expect(violations[0][:description]).to be_instance_of(String)
   end
 
   it 'skips declared exclusions' do
@@ -105,9 +106,10 @@ describe Cane::AbcCheck do
       abc_max:        0,
       abc_exclude: exclusions
     ).violations
-    violations.length.should == 1
-    violations[0].values_at(:file, :label, :value).should ==
+    expect(violations.length).to eq(1)
+    expect(violations[0].values_at(:file, :label, :value)).to eq(
       [file_name, "Harness::Nested#other_meth", 1]
+    )
   end
 
   it "creates an AbcMaxViolation for method in assigned anonymous class" do
@@ -135,7 +137,7 @@ describe Cane::AbcCheck do
     RUBY
 
     violations = check(file_name, abc_max: 1).violations
-    violations[0][:label].should == "(anon)#test_method"
+    expect(violations[0][:label]).to eq("(anon)#test_method")
   end
 
   def self.it_should_extract_method_name(name, label=name, sep='#')
@@ -150,7 +152,7 @@ describe Cane::AbcCheck do
       RUBY
 
       violations = check(file_name, abc_max: 1).violations
-      violations[0][:label].should == "Harness#{sep}#{label}"
+      expect(violations[0][:label]).to eq("Harness#{sep}#{label}")
     end
   end
 

--- a/spec/cane_spec.rb
+++ b/spec/cane_spec.rb
@@ -49,12 +49,12 @@ describe 'The cane application' do
       --check #{class_name}
       --unhappy-file #{fn}
     )
-    output.should include("Lines violated style requirements")
-    output.should include("Methods exceeded maximum allowed ABC complexity")
-    output.should include(
+    expect(output).to include("Lines violated style requirements")
+    expect(output).to include("Methods exceeded maximum allowed ABC complexity")
+    expect(output).to include(
       "Class and Module definitions require explanatory comments"
     )
-    exitstatus.should == 1
+    expect(exitstatus).to eq(1)
   end
 
   it 'handles invalid unicode input' do
@@ -62,19 +62,19 @@ describe 'The cane application' do
 
     _, exitstatus = run("--style-glob #{fn} --abc-glob #{fn} --doc-glob #{fn}")
 
-    exitstatus.should == 0
+    expect(exitstatus).to eq(0)
   end
 
   it 'can run tasks in parallel' do
     # This spec isn't great, but there is no good way to actually observe that
     # tasks run in parallel and we want to verify the conditional is correct.
-    Cane.task_runner(parallel: true).should == Parallel
+    expect(Cane.task_runner(parallel: true)).to eq(Parallel)
   end
 
   it 'colorizes output' do
     output, exitstatus = run("--color --abc-max 0")
 
-    output.should include("\e[31m")
+    expect(output).to include("\e[31m")
   end
 
   after do

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -9,16 +9,16 @@ describe Cane::CLI do
     let!(:cane)   { class_double("Cane").as_stubbed_const }
 
     it 'runs Cane with the given arguments' do
-      parser.should_receive(:parse).with("--args").and_return(args: true)
-      cane.should_receive(:run).with(args: true).and_return("tracer")
+      expect(parser).to receive(:parse).with("--args").and_return(args: true)
+      expect(cane).to receive(:run).with(args: true).and_return("tracer")
 
-      described_class.run("--args").should == "tracer"
+      expect(described_class.run("--args")).to eq("tracer")
     end
 
     it 'does not run Cane if parser was able to handle input' do
-      parser.should_receive(:parse).with("--args").and_return("tracer")
+      expect(parser).to receive(:parse).with("--args").and_return("tracer")
 
-      described_class.run("--args").should == "tracer"
+      expect(described_class.run("--args")).to eq("tracer")
     end
   end
 end

--- a/spec/doc_check_spec.rb
+++ b/spec/doc_check_spec.rb
@@ -43,19 +43,19 @@ end
     RUBY
 
     violations = check(file_name).violations
-    violations.length.should == 3
+    expect(violations.length).to eq(3)
 
-    violations[0].values_at(:file, :line, :label).should == [
+    expect(violations[0].values_at(:file, :line, :label)).to eq([
       file_name, 3, "NoDoc"
-    ]
+    ])
 
-    violations[1].values_at(:file, :line, :label).should == [
+    expect(violations[1].values_at(:file, :line, :label)).to eq([
       file_name, 15, "AlsoNeedsDoc"
-    ]
+    ])
 
-    violations[2].values_at(:file, :line, :label).should == [
+    expect(violations[2].values_at(:file, :line, :label)).to eq([
       file_name, 17, "ButThisNeedsDoc"
-    ]
+    ])
   end
 
   it 'does not create violations for single line classes without methods' do
@@ -71,15 +71,15 @@ end
 RUBY
 
     violations = check(file_name).violations
-    violations.length.should == 2
+    expect(violations.length).to eq(2)
 
-    violations[0].values_at(:file, :line, :label).should == [
+    expect(violations[0].values_at(:file, :line, :label)).to eq([
       file_name, 1, "NeedsDoc"
-    ]
+    ])
 
-    violations[1].values_at(:file, :line, :label).should == [
+    expect(violations[1].values_at(:file, :line, :label)).to eq([
       file_name, 2, "AlsoNeedsDoc"
-    ]
+    ])
   end
 
   it 'ignores magic encoding comments' do
@@ -93,39 +93,41 @@ class Doc; end
     RUBY
 
     violations = check(file_name).violations
-    violations.length.should == 2
+    expect(violations.length).to eq(2)
 
-    violations[0].values_at(:file, :line, :label).should == [
+    expect(violations[0].values_at(:file, :line, :label)).to eq([
       file_name, 2, "NoDoc"
-    ]
-    violations[1].values_at(:file, :line, :label).should == [
+    ])
+    expect(violations[1].values_at(:file, :line, :label)).to eq([
       file_name, 4, "AlsoNoDoc"
-    ]
+    ])
   end
 
   it 'creates a violation for missing README' do
     file = class_double("Cane::File").as_stubbed_const
     stub_const("Cane::File", file)
-    file.should_receive(:case_insensitive_glob).with("README*").and_return([])
+    expect(file).to receive(:case_insensitive_glob).with(
+      "README*"
+    ).and_return([])
 
     violations = check("").violations
-    violations.length.should == 1
+    expect(violations.length).to eq(1)
 
-    violations[0].values_at(:description, :label).should == [
+    expect(violations[0].values_at(:description, :label)).to eq([
       "Missing documentation", "No README found"
-    ]
+    ])
   end
 
   it 'does not create a violation when readme exists' do
     file = class_double("Cane::File").as_stubbed_const
     stub_const("Cane::File", file)
-    file
-      .should_receive(:case_insensitive_glob)
+    expect(file)
+      .to receive(:case_insensitive_glob)
       .with("README*")
       .and_return(%w(readme.md))
 
     violations = check("").violations
-    violations.length.should == 0
+    expect(violations.length).to eq(0)
   end
 
   it 'skips declared exclusions' do
@@ -138,7 +140,7 @@ class Doc; end
       doc_exclude: [file_name]
     ).violations
 
-    violations.length.should == 0
+    expect(violations.length).to eq(0)
   end
 
   it 'skips declared glob-based exclusions' do
@@ -151,7 +153,7 @@ class Doc; end
       doc_exclude: ["#{File.dirname(file_name)}/*"]
     ).violations
 
-    violations.length.should == 0
+    expect(violations.length).to eq(0)
   end
 
   it 'skips class inside an array' do
@@ -163,6 +165,6 @@ class Doc; end
     RUBY
 
     violations = check(file_name).violations
-    violations.length.should == 0
+    expect(violations.length).to eq(0)
   end
 end

--- a/spec/encoding_aware_iterator_spec.rb
+++ b/spec/encoding_aware_iterator_spec.rb
@@ -9,18 +9,18 @@ describe Cane::EncodingAwareIterator do
   it 'handles non-UTF8 input' do
     lines = ["\xc3\x28"]
     result = described_class.new(lines).map.with_index do |line, number|
-      line.should be_kind_of(String)
+      expect(line).to be_kind_of(String)
       [line =~ /\s/, number]
     end
-    result.should == [[nil, 0]]
+    expect(result).to eq([[nil, 0]])
   end
 
   it 'does not enter an infinite loop on persistently bad input' do
-    ->{
+    expect{
       described_class.new([""]).map.with_index do |line, number|
         "\xc3\x28" =~ /\s/
       end
-    }.should raise_error(ArgumentError)
+    }.to raise_error(ArgumentError)
   end
 
   it 'allows each with no block' do
@@ -28,6 +28,6 @@ describe Cane::EncodingAwareIterator do
     described_class.new([""]).each.with_index do |line, number|
       called_with_line = line
     end
-    called_with_line.should == ""
+    expect(called_with_line).to eq("")
   end
 end

--- a/spec/file_spec.rb
+++ b/spec/file_spec.rb
@@ -17,7 +17,9 @@ describe Cane::File do
           expected.each do |x|
             FileUtils.touch(x)
           end
-          Cane::File.case_insensitive_glob("README*").should =~ expected
+          expect(Cane::File.case_insensitive_glob("README*")).to match_array(
+            expected
+          )
         end
       end
     end

--- a/spec/json_formatter_spec.rb
+++ b/spec/json_formatter_spec.rb
@@ -5,7 +5,8 @@ require 'cane/json_formatter'
 describe Cane::JsonFormatter do
   it 'outputs violations as JSON' do
     violations = [{description: 'Fail', line: 3}]
-    JSON.parse(described_class.new(violations).to_s).should ==
+    expect(JSON.parse(described_class.new(violations).to_s)).to eq(
       [{'description' => 'Fail', 'line' => 3}]
+    )
   end
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -13,71 +13,71 @@ describe Cane::CLI::Parser do
 
   it 'allows style options to be configured' do
     output, result = run("--style-glob myfile --style-measure 3")
-    result[:style_glob].should == 'myfile'
-    result[:style_measure].should == 3
+    expect(result[:style_glob]).to eq('myfile')
+    expect(result[:style_measure]).to eq(3)
   end
 
   it 'allows checking gte of a value in a file' do
     output, result = run("--gte myfile,90")
-    result[:gte].should == [['myfile', '90']]
+    expect(result[:gte]).to eq([['myfile', '90']])
   end
 
   it 'allows checking eq of a value in a file' do
     output, result = run("--eq myfile,90")
-    result[:eq].should == [['myfile', '90']]
+    expect(result[:eq]).to eq([['myfile', '90']])
   end
 
   it 'allows checking lte of a value in a file' do
     output, result = run("--lte myfile,90")
-    result[:lte].should == [['myfile', '90']]
+    expect(result[:lte]).to eq([['myfile', '90']])
   end
 
   it 'allows checking lt of a value in a file' do
     output, result = run("--lt myfile,90")
-    result[:lt].should == [['myfile', '90']]
+    expect(result[:lt]).to eq([['myfile', '90']])
   end
 
   it 'allows checking gt of a value in a file' do
     output, resugt = run("--gt myfile,90")
-    resugt[:gt].should == [['myfile', '90']]
+    expect(resugt[:gt]).to eq([['myfile', '90']])
   end
 
   it 'allows upper bound of failed checks' do
     output, result = run("--max-violations 1")
-    result[:max_violations].should == 1
+    expect(result[:max_violations]).to eq(1)
   end
 
   it 'uses positional arguments as shortcut for individual files' do
     output, result = run("--all mysinglefile")
-    result[:abc_glob].should == 'mysinglefile'
-    result[:style_glob].should == 'mysinglefile'
-    result[:doc_glob].should == 'mysinglefile'
+    expect(result[:abc_glob]).to eq('mysinglefile')
+    expect(result[:style_glob]).to eq('mysinglefile')
+    expect(result[:doc_glob]).to eq('mysinglefile')
 
     output, result = run("--all mysinglefile --abc-glob myotherfile")
-    result[:abc_glob].should == 'myotherfile'
-    result[:style_glob].should == 'mysinglefile'
-    result[:doc_glob].should == 'mysinglefile'
+    expect(result[:abc_glob]).to eq('myotherfile')
+    expect(result[:style_glob]).to eq('mysinglefile')
+    expect(result[:doc_glob]).to eq('mysinglefile')
   end
 
   it 'displays a help message' do
     output, result = run("--help")
 
-    result.should be
-    output.should include("Usage:")
+    expect(result).to be
+    expect(output).to include("Usage:")
   end
 
   it 'handles invalid options by showing help' do
     output, result = run("--bogus")
 
-    output.should include("Usage:")
-    result.should_not be
+    expect(output).to include("Usage:")
+    expect(result).not_to be
   end
 
   it 'displays version' do
     output, result = run("--version")
 
-    result.should be
-    output.should include(Cane::VERSION)
+    expect(result).to be
+    expect(output).to include(Cane::VERSION)
   end
 
   it 'supports exclusions' do
@@ -88,18 +88,18 @@ describe Cane::CLI::Parser do
     ].join(' ')
 
     _, result = run(options)
-    result[:abc_exclude].should == [['Harness#complex_method']]
-    result[:doc_exclude].should == [['myfile']]
-    result[:style_exclude].should == [['myfile']]
+    expect(result[:abc_exclude]).to eq([['Harness#complex_method']])
+    expect(result[:doc_exclude]).to eq([['myfile']])
+    expect(result[:style_exclude]).to eq([['myfile']])
   end
 
   describe 'argument ordering' do
     it 'gives precedence to the last argument #1' do
       _, result = run("--doc-glob myfile --no-doc")
-      result[:no_doc].should be
+      expect(result[:no_doc]).to be
 
       _, result = run("--no-doc --doc-glob myfile")
-      result[:no_doc].should_not be
+      expect(result[:no_doc]).not_to be
     end
   end
 
@@ -111,34 +111,34 @@ describe Cane::CLI::Parser do
     EOS
     file = class_double("Cane::File").as_stubbed_const
     stub_const("Cane::File", file)
-    file.should_receive(:exists?).with('./.cane').and_return(true)
-    file.should_receive(:contents).with('./.cane').and_return(defaults)
+    expect(file).to receive(:exists?).with('./.cane').and_return(true)
+    expect(file).to receive(:contents).with('./.cane').and_return(defaults)
 
     _, result = run("--style-glob myotherfile")
 
-    result[:no_doc].should be
-    result[:abc_glob].should == 'myfile'
-    result[:style_glob].should == 'myotherfile'
+    expect(result[:no_doc]).to be
+    expect(result[:abc_glob]).to eq('myfile')
+    expect(result[:style_glob]).to eq('myotherfile')
   end
 
   it 'allows parallel option' do
     _, result = run("--parallel")
-    result[:parallel].should be
+    expect(result[:parallel]).to be
   end
 
   it 'handles ambiguous options' do
     output, result = run("-abc-max")
-    output.should include("Usage:")
-    result.should_not be
+    expect(output).to include("Usage:")
+    expect(result).not_to be
   end
 
   it 'handles no_readme option' do
     _, result = run("--no-readme")
-    result[:no_readme].should be
+    expect(result[:no_readme]).to be
   end
 
   it 'handles json option' do
     _, result = run("--json")
-    result[:json].should be
+    expect(result[:json]).to be
   end
 end

--- a/spec/rake_task_spec.rb
+++ b/spec/rake_task_spec.rb
@@ -21,15 +21,15 @@ describe Cane::RakeTask do
       cane.parallel = false
     end
 
-    task.no_abc.should == true
+    expect(task.no_abc).to eq(true)
 
-    task.should_receive(:abort)
+    expect(task).to receive(:abort)
     out = capture_stdout do
       Rake::Task['quality'].invoke
     end
 
-    out.should include("Quality threshold crossed")
-    out.should include("theopt")
+    expect(out).to include("Quality threshold crossed")
+    expect(out).to include("theopt")
   end
 
   it 'can be configured using a .cane file' do
@@ -39,12 +39,12 @@ describe Cane::RakeTask do
       cane.canefile = make_file(conf)
     end
 
-    task.should_receive(:abort)
+    expect(task).to receive(:abort)
     out = capture_stdout do
       Rake::Task['canefile_quality'].invoke
     end
 
-    out.should include("Quality threshold crossed")
+    expect(out).to include("Quality threshold crossed")
   end
 
   it 'defaults to using a canefile without a block' do
@@ -54,12 +54,12 @@ describe Cane::RakeTask do
 
       task = Cane::RakeTask.new(:canefile_quality)
 
-      task.should_receive(:abort)
+      expect(task).to receive(:abort)
       out = capture_stdout do
         Rake::Task['canefile_quality'].invoke
       end
 
-      out.should include("Quality threshold crossed")
+      expect(out).to include("Quality threshold crossed")
     end
   end
 

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -5,20 +5,20 @@ require 'cane/runner'
 describe Cane::Runner do
   describe '#run' do
     it 'returns true iff fewer violations than max allowed' do
-      described_class.new(checks: [], max_violations: 0).run.should be
-      described_class.new(checks: [], max_violations: -1).run.should_not be
+      expect(described_class.new(checks: [], max_violations: 0).run).to be
+      expect(described_class.new(checks: [], max_violations: -1).run).not_to be
     end
 
     it 'returns JSON output' do
       formatter = class_double("Cane::JsonFormatter").as_stubbed_const
-      formatter.should_receive(:new).and_return("JSON")
+      expect(formatter).to receive(:new).and_return("JSON")
       buffer = StringIO.new("")
 
       described_class.new(
         out: buffer, checks: [], max_violations: 0, json: true
       ).run
 
-      buffer.string.should == "JSON"
+      expect(buffer.string).to eq("JSON")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,15 +37,15 @@ end
 RSpec::Matchers.define :have_violation do |label|
   match do |check|
     violations = check.violations
-    violations.length.should == 1
-    violations[0][:label].should == label
+    expect(violations.length).to eq(1)
+    expect(violations[0][:label]).to eq(label)
   end
 end
 
 RSpec::Matchers.define :have_no_violations do |label|
   match do |check|
     violations = check.violations
-    violations.length.should == 0
+    expect(violations.length).to eq(0)
   end
 end
 

--- a/spec/style_check_spec.rb
+++ b/spec/style_check_spec.rb
@@ -19,7 +19,7 @@ describe Cane::StyleCheck do
     file_name = make_file(ruby_with_style_issue)
 
     violations = check(file_name, style_measure: 8).violations
-    violations.length.should == 3
+    expect(violations.length).to eq(3)
   end
 
   it 'skips declared exclusions' do
@@ -30,7 +30,7 @@ describe Cane::StyleCheck do
       style_exclude: [file_name]
     ).violations
 
-    violations.length.should == 0
+    expect(violations.length).to eq(0)
   end
 
   it 'skips declared glob-based exclusions' do
@@ -41,7 +41,7 @@ describe Cane::StyleCheck do
       style_exclude: ["#{File.dirname(file_name)}/*"]
     ).violations
 
-    violations.length.should == 0
+    expect(violations.length).to eq(0)
   end
 
   it 'does not include trailing new lines in the character count' do
@@ -52,7 +52,7 @@ describe Cane::StyleCheck do
       style_exclude: [file_name]
     ).violations
 
-    violations.length.should == 0
+    expect(violations.length).to eq(0)
   end
 
 end

--- a/spec/threshold_check_spec.rb
+++ b/spec/threshold_check_spec.rb
@@ -22,14 +22,14 @@ describe Cane::ThresholdCheck do
 
     context "when the current coverage cannot be read" do
       it do
-        run(:gte, 20).should \
+        expect(run(:gte, 20)).to \
           have_violation('x is unavailable, should be >= 20.0')
       end
     end
 
     context "when the coverage threshold is incorrectly specified" do
       it do
-        described_class.new(gte: [['20', 'bogus_file']]).should \
+        expect(described_class.new(gte: [['20', 'bogus_file']])).to \
           have_violation('bogus_file is not a number or a file')
       end
     end
@@ -38,37 +38,53 @@ describe Cane::ThresholdCheck do
       before do
         file = class_double("Cane::File").as_stubbed_const
         stub_const("Cane::File", file)
-        file.should_receive(:contents).with('x').and_return("8\n")
+        expect(file).to receive(:contents).with('x').and_return("8\n")
       end
 
       context '>' do
-        it { run(:gt, 7).should have_no_violations }
-        it { run(:gt, 8).should have_violation('x is 8.0, should be > 8.0') }
-        it { run(:gt, 9).should have_violation('x is 8.0, should be > 9.0') }
+        it { expect(run(:gt, 7)).to have_no_violations }
+        it {
+          expect(run(:gt, 8)).to have_violation('x is 8.0, should be > 8.0')
+        }
+        it {
+          expect(run(:gt, 9)).to have_violation('x is 8.0, should be > 9.0')
+        }
       end
 
       context '>=' do
-        it { run(:gte, 7).should have_no_violations }
-        it { run(:gte, 8).should have_no_violations }
-        it { run(:gte, 9).should have_violation('x is 8.0, should be >= 9.0') }
+        it { expect(run(:gte, 7)).to have_no_violations }
+        it { expect(run(:gte, 8)).to have_no_violations }
+        it {
+          expect(run(:gte, 9)).to have_violation('x is 8.0, should be >= 9.0')
+        }
       end
 
       context '==' do
-        it { run(:eq, 7).should have_violation('x is 8.0, should be == 7.0') }
-        it { run(:eq, 8).should have_no_violations }
-        it { run(:eq, 9).should have_violation('x is 8.0, should be == 9.0') }
+        it {
+          expect(run(:eq, 7)).to have_violation('x is 8.0, should be == 7.0')
+        }
+        it { expect(run(:eq, 8)).to have_no_violations }
+        it {
+          expect(run(:eq, 9)).to have_violation('x is 8.0, should be == 9.0')
+        }
       end
 
       context '<=' do
-        it { run(:lte, 7).should have_violation('x is 8.0, should be <= 7.0') }
-        it { run(:lte, 8).should have_no_violations }
-        it { run(:lte, 9).should have_no_violations }
+        it {
+          expect(run(:lte, 7)).to have_violation('x is 8.0, should be <= 7.0')
+        }
+        it { expect(run(:lte, 8)).to have_no_violations }
+        it { expect(run(:lte, 9)).to have_no_violations }
       end
 
       context '<' do
-        it { run(:lt, 7).should have_violation('x is 8.0, should be < 7.0') }
-        it { run(:lt, 8).should have_violation('x is 8.0, should be < 8.0') }
-        it { run(:lt, 9).should have_no_violations }
+        it {
+          expect(run(:lt, 7)).to have_violation('x is 8.0, should be < 7.0')
+        }
+        it {
+          expect(run(:lt, 8)).to have_violation('x is 8.0, should be < 8.0')
+        }
+        it { expect(run(:lt, 9)).to have_no_violations }
       end
     end
 
@@ -76,25 +92,27 @@ describe Cane::ThresholdCheck do
 
   context "normalizing a user supplied value to a threshold" do
     it "normalizes an integer to itself" do
-      subject.normalized_limit(99).should == 99
+      expect(subject.normalized_limit(99)).to eq(99)
     end
 
     it "normalizes a float to itself" do
-      subject.normalized_limit(99.6).should == 99.6
+      expect(subject.normalized_limit(99.6)).to eq(99.6)
     end
 
     it "normalizes a valid file to its contents" do
-      subject.normalized_limit(make_file('99.5')).should == 99.5
+      expect(subject.normalized_limit(make_file('99.5'))).to eq(99.5)
     end
 
     it "normalizes an invalid file to an unavailable value" do
       limit = subject.normalized_limit("/File.does.not.exist")
-      limit.should be_a Cane::ThresholdCheck::UnavailableValue
+      expect(limit).to be_a Cane::ThresholdCheck::UnavailableValue
     end
 
 
     it 'normalizes a json file to a float' do
-      subject.normalized_limit(make_file(simplecov_last_run)).should == 93.88
+      expect(subject.normalized_limit(make_file(simplecov_last_run))).to eq(
+        93.88
+      )
     end
 
   end

--- a/spec/violation_formatter_spec.rb
+++ b/spec/violation_formatter_spec.rb
@@ -10,30 +10,30 @@ describe Cane::ViolationFormatter do
   end
 
   it 'includes number of violations in the group header' do
-    described_class.new([violation("FAIL")]).to_s.should include("(1)")
+    expect(described_class.new([violation("FAIL")]).to_s).to include("(1)")
   end
 
   it 'includes total number of violations' do
     violations = [violation("FAIL1"), violation("FAIL2")]
     result = described_class.new(violations).to_s
-    result.should include("Total Violations: 2")
+    expect(result).to include("Total Violations: 2")
   end
 
   it 'does not colorize output by default' do
     result = described_class.new([violation("FAIL")]).to_s
-    result.should_not include("\e[31m")
+    expect(result).not_to include("\e[31m")
   end
 
   it 'colorizes output when passed color: true' do
     result = described_class.new([violation("FAIL")], color: true).to_s
-    result.should include("\e[31m")
-    result.should include("\e[0m")
+    expect(result).to include("\e[31m")
+    expect(result).to include("\e[0m")
   end
 
   it 'does not colorize output if max_violations is not crossed' do
     options = { color: true, max_violations: 1 }
     result = described_class.new([violation("FAIL")], options).to_s
 
-    result.should_not include("\e[31m")
+    expect(result).not_to include("\e[31m")
   end
 end


### PR DESCRIPTION
This conversion is done by Transpec 1.13.1 with the following command:
    transpec
- 112 conversions
  from: obj.should
    to: expect(obj).to
- 66 conversions
  from: == expected
    to: eq(expected)
- 12 conversions
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)
- 6 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 1 conversion
  from: -> { }.should
    to: expect { }.to
- 1 conversion
  from: =~ [1, 2]
    to: match_array([1, 2])

Fix style violations
