### PR TITLE
Use Dir.glob instead of Dir.[]

### DIFF
--- a/lib/cane/abc_check.rb
+++ b/lib/cane/abc_check.rb
@@ -179,7 +179,7 @@ module Cane
     end
 
     def file_names
-      Dir[opts.fetch(:abc_glob)]
+      Dir.glob(opts.fetch(:abc_glob))
     end
 
     def order(result)

--- a/lib/cane/doc_check.rb
+++ b/lib/cane/doc_check.rb
@@ -114,7 +114,7 @@ module Cane
     end
 
     def file_names
-      Dir[opts.fetch(:doc_glob)].reject { |file| excluded?(file) }
+      Dir.glob(opts.fetch(:doc_glob)).reject { |file| excluded?(file) }
     end
 
     def method_definition?(line)
@@ -139,7 +139,7 @@ module Cane
 
     def exclusions
       @exclusions ||= opts.fetch(:doc_exclude, []).flatten.map do |i|
-        Dir[i]
+        Dir.glob(i)
       end.flatten.to_set
     end
 

--- a/lib/cane/style_check.rb
+++ b/lib/cane/style_check.rb
@@ -60,7 +60,7 @@ module Cane
     end
 
     def file_list
-      Dir[opts.fetch(:style_glob)].reject {|f| excluded?(f) }
+      Dir.glob(opts.fetch(:style_glob)).reject {|f| excluded?(f) }
     end
 
     def measure
@@ -73,7 +73,7 @@ module Cane
 
     def exclusions
       @exclusions ||= opts.fetch(:style_exclude, []).flatten.map do |i|
-        Dir[i]
+        Dir.glob(i)
       end.flatten.to_set
     end
 

--- a/spec/abc_check_spec.rb
+++ b/spec/abc_check_spec.rb
@@ -163,4 +163,21 @@ describe Cane::AbcCheck do
   it_should_extract_method_name 'GET'
   it_should_extract_method_name '`'
   it_should_extract_method_name '>='
+
+  describe "#file_names" do
+    context "abc_glob is an array" do
+      it "returns an array of relative file paths" do
+        glob = [
+          'spec/fixtures/a/**/*.{rb,prawn}',
+          'spec/fixtures/b/**/*.rb'
+        ]
+        check = described_class.new(abc_glob: glob)
+        expect(check.send(:file_names)).to eq([
+          'spec/fixtures/a/1.rb',
+          'spec/fixtures/a/3.prawn',
+          'spec/fixtures/b/1.rb'
+        ])
+      end
+    end
+  end
 end

--- a/spec/fixtures/a/1.rb
+++ b/spec/fixtures/a/1.rb
@@ -1,0 +1,1 @@
+puts "wooo I am a/1.rb"

--- a/spec/fixtures/a/2/i.haml
+++ b/spec/fixtures/a/2/i.haml
@@ -1,0 +1,1 @@
+= select_tag :typical_rails_field, options_from_collection_for_select(@collection, :this_line_is, :deliberately_long)

--- a/spec/fixtures/a/3.prawn
+++ b/spec/fixtures/a/3.prawn
@@ -1,0 +1,2 @@
+# .prawn files are actually ruby files, so
+# it makes sense to run ABC check on them.

--- a/spec/fixtures/b/1.rb
+++ b/spec/fixtures/b/1.rb
@@ -1,0 +1,1 @@
+puts "wooo I am b/1.rb"

--- a/spec/fixtures/b/2.prawn
+++ b/spec/fixtures/b/2.prawn
@@ -1,0 +1,2 @@
+# .prawn files are actually ruby files, so
+# it makes sense to run ABC check on them.

--- a/spec/fixtures/b/3/i.haml
+++ b/spec/fixtures/b/3/i.haml
@@ -1,0 +1,4 @@
+%ul
+  %li banana
+  %li kiwi
+  %li mango

--- a/spec/fixtures/c/1.md
+++ b/spec/fixtures/c/1.md
@@ -1,0 +1,2 @@
+I'm a markdown file!
+====

--- a/spec/style_check_spec.rb
+++ b/spec/style_check_spec.rb
@@ -55,4 +55,35 @@ describe Cane::StyleCheck do
     expect(violations.length).to eq(0)
   end
 
+  describe "#file_list" do
+    context "style_glob is an array" do
+      it "returns an array of relative file paths" do
+        glob = [
+          'spec/fixtures/a/**/*.{rb,prawn}',
+          'spec/fixtures/b/**/*.haml'
+        ]
+        check = described_class.new(style_glob: glob)
+        expect(check.send(:file_list)).to eq([
+          'spec/fixtures/a/1.rb',
+          'spec/fixtures/a/3.prawn',
+          'spec/fixtures/b/3/i.haml'
+        ])
+      end
+    end
+
+    context "style_exclude is an array" do
+      it "returns an array of relative file paths" do
+        glob = [
+          'spec/fixtures/a/**/*.{rb,prawn}',
+          'spec/fixtures/b/**/*.haml'
+        ]
+        exclude = [
+          'spec/fixtures/a/**/*.prawn',
+          'spec/fixtures/b/**/*.haml'
+        ]
+        check = described_class.new(style_exclude: exclude, style_glob: glob)
+        expect(check.send(:file_list)).to eq(['spec/fixtures/a/1.rb'])
+      end
+    end
+  end
 end


### PR DESCRIPTION
I want to pass an array to `style_glob`.  For example:

```
cane.style_glob = [
  'app/**/*.{rb,haml,prawn}',
  'config/**/*.rb'
]
```

Using `Dir.[]`, it seems this configuration is not possible.

```
bin/rake quality --trace
TypeError: no implicit conversion of Array into String
cane-2.6.2/lib/cane/style_check.rb:63:in `[]'
cane-2.6.2/lib/cane/style_check.rb:63:in `file_list'
```

Then again, I haven't looked into this in any great depth.  Or, maybe there's a way to do this in a single glob string?

Thanks for the great library, I've been using it for two years now as part of my build process.