### PR TITLE
Compatibility with Rake 11

### DIFF
--- a/lib/cane/rake_task.rb
+++ b/lib/cane/rake_task.rb
@@ -60,7 +60,7 @@ module Cane
         self.canefile = './.cane'
       end
 
-      unless ::Rake.application.last_comment
+      unless ::Rake.application.last_description
         desc %(Check code quality metrics with cane)
       end
 


### PR DESCRIPTION
The `TaskManager#last_comment` has been removed in [Rake 11](https://github.com/ruby/rake/blob/master/History.rdoc#1100--2016-03-09). We are to migrate to `TaskManager#last_description`.

The `#last_description` method has been available for many years so backwards compatibility is not a problem.